### PR TITLE
fix(SGV05): add disable button

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
                         <label for="nao-gostei">Não gostei</label>
                     </div>
                 </fieldset>
-                <button type="button" class="button is-success mt-4" id="btnSend" disabled>Enviar voto</button>
+                <button type="button"  class="button is-success mt-4 disabled" id="btnSend">Enviar voto</button>
             </form>
         </div>
     </section>

--- a/script.js
+++ b/script.js
@@ -18,11 +18,20 @@ function erroMessage() {
     }
 }
 
+function remodelButton() {
+    const botao = document.querySelector('.disabled');
+    botao.style.cursor = 'pointer';
+    botao.style.opacity = '1';
+}
+
 function checkSelection(radio) {
+    remodelButton();
+
     if (radio.value) {
-        // const strong = document.querySelector('strong');
+        const strong = document.querySelector('strong');
         document.querySelector('form').removeChild(strong);
         document.getElementById('btnSend').disabled = false;
+        remodelButton();
     }
 }
 
@@ -34,6 +43,8 @@ function receiveURL() {
     if (radio && radio.type === 'radio') {
         radio.checked = true;
         document.getElementById('btnSend').disabled = false;
+        remodelButton();
+
     }
 }
 

--- a/script.js
+++ b/script.js
@@ -14,24 +14,23 @@ function erroMessage() {
         strong.appendChild(text);
         strong.classList.add('has-text-danger');
         document.querySelector('form').appendChild(strong);
-        document.getElementById('btnSend').disabled = true;
     }
 }
 
-function remodelButton() {
-    const botao = document.querySelector('.disabled');
-    botao.style.cursor = 'pointer';
-    botao.style.opacity = '1';
+function unlockButton() {
+    const activateButton = document.querySelector('.disabled');
+    activateButton.classList.remove('disabled');
 }
 
 function checkSelection(radio) {
-    remodelButton();
+    unlockButton();
 
     if (radio.value) {
         const strong = document.querySelector('strong');
-        document.querySelector('form').removeChild(strong);
-        document.getElementById('btnSend').disabled = false;
-        remodelButton();
+        if (strong) {
+            document.querySelector('form').removeChild(strong);
+        }
+        unlockButton();
     }
 }
 
@@ -42,9 +41,7 @@ function receiveURL() {
     const radio = document.getElementById(parameter);
     if (radio && radio.type === 'radio') {
         radio.checked = true;
-        document.getElementById('btnSend').disabled = false;
-        remodelButton();
-
+        unlockButton();
     }
 }
 

--- a/script.js
+++ b/script.js
@@ -23,7 +23,6 @@ function unlockButton() {
 }
 
 function checkSelection(radio) {
-    unlockButton();
 
     if (radio.value) {
         const strong = document.querySelector('strong');

--- a/style.css
+++ b/style.css
@@ -2,4 +2,8 @@
     font-family: Arial, Helvetica, sans-serif;
 }
 
+.disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
 

--- a/style.css
+++ b/style.css
@@ -5,5 +5,9 @@
 .disabled {
     cursor: not-allowed;
     opacity: 0.5;
-  }
+}
 
+.enabled {
+    cursor: pointer;
+    opacity: 1;
+}


### PR DESCRIPTION
![img1](https://github.com/user-attachments/assets/059fbb9f-7973-4b6e-a3aa-216c0b6a56af)
Como solicitado caso nenhum atividade é reconhecida o sistema matem o botão com a aparência de desabilitado utilizando estilos CSS.

![img2](https://github.com/user-attachments/assets/fd30057a-b1a3-43ff-8caa-3db2d4c8d9e8)
É como esperado caso o usuário selecione alguma opção automaticamente o botão enviar e habilidade utilizando a função remodelButton() que e usada para modificar os parâmetros CSS diretamente pelo javaScript. 

![img3](https://github.com/user-attachments/assets/4e5f62be-3628-4a7c-b199-c608ce0e28ec)
 Caso o usuário acesse o sistema de voto diretamente pela URL, como o parâmetro vote="", o botão e habilidade ao carregar a pagina, sendo assim não veremos a mensagem de erro.

![img4](https://github.com/user-attachments/assets/f808b300-ddcd-444c-a503-e78b7c77e820)
Quando o usuário final clica no botão enviar e não seleciona nenhuma opção de voto, a mensagem de erro é exibida.

![gif1](https://github.com/user-attachments/assets/a765b76f-d7bd-4f8d-806e-0387290997f0)
Por último, mas não menos importante, quando clicamos no botão, ele mostra a mensagem de erro; quando selecionamos alguma opção de voto, a mensagem é desabilitada.